### PR TITLE
fix load handler password check

### DIFF
--- a/src/httpServer/handlers.go
+++ b/src/httpServer/handlers.go
@@ -238,7 +238,7 @@ func (s *Server) GetTimeoutsHandler() appHandler {
             return &appError{ "The \"username\" field is required ", http.StatusBadRequest, nil}
         }
         pass := r.FormValue("password")
-        if  user == "" {
+        if  pass == "" {
             return &appError{ "The \"password\" field is required ", http.StatusBadRequest, nil}
         }
         res, err := plugin.Load(bytes.NewReader(buf.Bytes()), user, pass);


### PR DESCRIPTION
minor fix to driver `handlers.go` where only `username` form data was being validated correctly